### PR TITLE
Add missing api scope

### DIFF
--- a/partyfy/assets/Constants.js
+++ b/partyfy/assets/Constants.js
@@ -2,7 +2,7 @@ const LOCAL_CONSTANTS = {
     SPOTIFY_CLIENT_ID : '56b011ba0994424ea55cd9f2205c6439',
     SPOTIFY_REDIRECT_URL : 'https://dev.partyfy.mattvandenberg.com',
     SPOTIFY_API_URI : 'http://localhost:8080/',
-    SPOTIFY_SCOPES : 'user-read-playback-state user-read-private user-read-email',
+    SPOTIFY_SCOPES : 'user-modify-playback-state user-read-playback-state user-read-private user-read-email',
 }
 
 export const CONSTANTS = {


### PR DESCRIPTION
Add Spotify Scope, which was prevent users from adding desired songs to their friend's queue.